### PR TITLE
Update HOWTO-Install-and-Configure-a-Shibboleth-IdP-v5.x-on-Debian-Ub…

### DIFF
--- a/idem-fedops/HOWTO-Shibboleth/Identity Provider/Debian-Ubuntu/HOWTO-Install-and-Configure-a-Shibboleth-IdP-v5.x-on-Debian-Ubuntu-Linux-with-Apache-+-Jetty.md
+++ b/idem-fedops/HOWTO-Shibboleth/Identity Provider/Debian-Ubuntu/HOWTO-Install-and-Configure-a-Shibboleth-IdP-v5.x-on-Debian-Ubuntu-Linux-with-Apache-+-Jetty.md
@@ -308,7 +308,7 @@ Jetty is a Web server and a Java Servlet container. It will be used to run the I
         ```
 
     -   ``` text
-        chown -R jetty:jetty /opt/jetty /usr/local/src/jetty-src
+        chown -R jetty:jetty /opt/jetty /usr/local/src/jetty-src/
         ```
 
 7.  Create the Jetty Logs' folders:


### PR DESCRIPTION
…untu-Linux-with-Apache-+-Jetty.md

If you want to chown a linked tree you should terminate the path with a slash unless you want to chown the link itself