### PR TITLE
PasswordExpirationTime is not AD

### DIFF
--- a/idem-fedops/HOWTO-Shibboleth/Identity Provider/Debian-Ubuntu/HOWTO-Install-and-Configure-a-Shibboleth-IdP-v5.x-on-Debian-Ubuntu-Linux-with-Apache-+-Jetty.md
+++ b/idem-fedops/HOWTO-Shibboleth/Identity Provider/Debian-Ubuntu/HOWTO-Install-and-Configure-a-Shibboleth-IdP-v5.x-on-Debian-Ubuntu-Linux-with-Apache-+-Jetty.md
@@ -1000,7 +1000,7 @@ This Storage service will memorize User Consent data on a persistent SQL databas
             idp.authn.LDAP.trustCertificates = /opt/shibboleth-idp/credentials/ldap-server.crt
 
             # List of attributes to request during authentication
-            idp.authn.LDAP.returnAttributes = passwordExpirationTime,loginGraceRemaining
+            idp.authn.LDAP.returnAttributes = pwdLastSet,badPwdCount
 
             idp.authn.LDAP.baseDN = ou=people,dc=example,dc=org
             idp.authn.LDAP.subtreeSearch = false

--- a/idem-fedops/HOWTO-Shibboleth/Identity Provider/Debian-Ubuntu/HOWTO-Install-and-Configure-a-Shibboleth-IdP-v5.x-on-Debian-Ubuntu-Linux-with-Apache-+-Jetty.md
+++ b/idem-fedops/HOWTO-Shibboleth/Identity Provider/Debian-Ubuntu/HOWTO-Install-and-Configure-a-Shibboleth-IdP-v5.x-on-Debian-Ubuntu-Linux-with-Apache-+-Jetty.md
@@ -1000,7 +1000,7 @@ This Storage service will memorize User Consent data on a persistent SQL databas
             idp.authn.LDAP.trustCertificates = /opt/shibboleth-idp/credentials/ldap-server.crt
 
             # List of attributes to request during authentication
-            idp.authn.LDAP.returnAttributes = pwdLastSet,badPwdCount
+            idp.authn.LDAP.returnAttributes = pwdLastSet
 
             idp.authn.LDAP.baseDN = ou=people,dc=example,dc=org
             idp.authn.LDAP.subtreeSearch = false


### PR DESCRIPTION
The current How-To guide mentions the passwordExpirationTime parameter. 
However, this attribute belongs to eDirectory (LDAP) and is not present in Active Directory (AD).  Same thing for loginGraceRemaining.
In Active Directory does not exsist perfect substitutes for them, but some suggestions are made in the code, for some AD attributes with similar purposes.